### PR TITLE
chore: add listAll param on get all orders endpoint #75

### DIFF
--- a/src/FIAP.TechChallenge.ByteMeBurger.Api/Controllers/OrdersController.cs
+++ b/src/FIAP.TechChallenge.ByteMeBurger.Api/Controllers/OrdersController.cs
@@ -46,13 +46,15 @@ namespace FIAP.TechChallenge.ByteMeBurger.Api.Controllers
         /// <summary>
         /// Get all orders that are not Completed
         /// </summary>
+        /// <param name="listAll">If true it will return all orders. If false it returns only orders
+        /// with status (Received, In Preparation or Ready).</param>
         /// <param name="cancellationToken">Cancellation token</param>
-        /// <returns>Active orders list</returns>
+        /// <returns>Orders list</returns>
         [HttpGet]
-        public async Task<ActionResult<ReadOnlyCollection<OrderDto>>> Get(CancellationToken cancellationToken)
+        public async Task<ActionResult<ReadOnlyCollection<OrderDto>>> Get(bool listAll, CancellationToken cancellationToken)
         {
             logger.LogInformation("Getting all orders");
-            var orders = await orderService.GetAllAsync();
+            var orders = await orderService.GetAllAsync(listAll);
             var ordersDto = orders.Select(o => new OrderDto(o));
 
             logger.LogInformation("Retrieved {Count} orders", ordersDto.Count());

--- a/src/FIAP.TechChallenge.ByteMeBurger.Application/Services/OrderService.cs
+++ b/src/FIAP.TechChallenge.ByteMeBurger.Application/Services/OrderService.cs
@@ -30,9 +30,9 @@ public class OrderService(
         return order;
     }
 
-    public async Task<ReadOnlyCollection<Order>> GetAllAsync()
+    public async Task<ReadOnlyCollection<Order>> GetAllAsync(bool listAll)
     {
-        return await orderGetAllUseCase.Execute();
+        return await orderGetAllUseCase.Execute(listAll);
     }
 
     public async Task<Order?> GetAsync(Guid id)

--- a/src/FIAP.TechChallenge.ByteMeBurger.Application/UseCases/Orders/IOrderGetAllUseCase.cs
+++ b/src/FIAP.TechChallenge.ByteMeBurger.Application/UseCases/Orders/IOrderGetAllUseCase.cs
@@ -5,5 +5,11 @@ namespace FIAP.TechChallenge.ByteMeBurger.Application.UseCases.Orders;
 
 public interface IOrderGetAllUseCase
 {
-    Task<ReadOnlyCollection<Order>> Execute();
+    /// <summary>
+    /// Get all Orders
+    /// </summary>
+    /// <param name="listAll">If true it will return all orders. If false it returns only orders
+    /// with status (Received, In Preparation or Ready).</param>
+    /// <returns>Orders</returns>
+    Task<ReadOnlyCollection<Order>> Execute(bool listAll);
 }

--- a/src/FIAP.TechChallenge.ByteMeBurger.Application/UseCases/Orders/OrderGetAllUseCase.cs
+++ b/src/FIAP.TechChallenge.ByteMeBurger.Application/UseCases/Orders/OrderGetAllUseCase.cs
@@ -13,16 +13,15 @@ namespace FIAP.TechChallenge.ByteMeBurger.Application.UseCases.Orders;
 
 public class OrderGetAllUseCase(IOrderRepository repository) : IOrderGetAllUseCase
 {
-    public async Task<ReadOnlyCollection<Order>> Execute()
+    public async Task<ReadOnlyCollection<Order>> Execute(bool listAll)
     {
-        var orders = await repository.GetAllAsync();
-        return orders is null
-            ? Array.Empty<Order>().AsReadOnly()
-            : orders
-                .Where(o => o.Status == OrderStatus.Received || o.Status == OrderStatus.InPreparation ||
-                            o.Status == OrderStatus.Ready)
-                .OrderByDescending(o => o.Status)
-                .ToList()
-                .AsReadOnly();
+        var orders = (await repository.GetAllAsync() ?? Enumerable.Empty<Order>());
+        return (listAll
+                ? orders
+                : orders.Where(o => o.Status is OrderStatus.Received or OrderStatus.InPreparation or OrderStatus.Ready)
+            ).OrderByDescending(o => o.Status)
+            .ThenBy(o => o.Created)
+            .ToList()
+            .AsReadOnly();
     }
 }

--- a/src/FIAP.TechChallenge.ByteMeBurger.Domain/Interfaces/IOrderService.cs
+++ b/src/FIAP.TechChallenge.ByteMeBurger.Domain/Interfaces/IOrderService.cs
@@ -23,8 +23,10 @@ public interface IOrderService
     /// <summary>
     /// Get all active orders
     /// </summary>
+    /// <param name="listAll">If true it will return all orders. If false it returns only orders
+    /// with status (Received, In Preparation or Ready).</param>
     /// <returns>List of orders</returns>
-    Task<ReadOnlyCollection<Order>> GetAllAsync();
+    Task<ReadOnlyCollection<Order>> GetAllAsync(bool listAll);
 
     /// <summary>
     /// Get order detail

--- a/tests/FIAP.TechChallenge.ByteMeBurger.Api.Test/Controllers/OrdersControllerTest.cs
+++ b/tests/FIAP.TechChallenge.ByteMeBurger.Api.Test/Controllers/OrdersControllerTest.cs
@@ -52,11 +52,11 @@ public class OrdersControllerTest
             new(expectedOrder)
         };
 
-        _serviceMock.Setup(s => s.GetAllAsync())
+        _serviceMock.Setup(s => s.GetAllAsync(false))
             .ReturnsAsync(orders.ToList().AsReadOnly);
 
         // Act
-        var response = await _target.Get(CancellationToken.None);
+        var response = await _target.Get(false, CancellationToken.None);
 
         // Assert
         using (new AssertionScope())
@@ -64,7 +64,7 @@ public class OrdersControllerTest
             response.Result.Should().BeOfType<OkObjectResult>();
             response.Result.As<OkObjectResult>().Value.Should().BeEquivalentTo(expectedOrdersDto);
 
-            _serviceMock.Verify(o => o.GetAllAsync(), Times.Once);
+            _serviceMock.Verify(o => o.GetAllAsync(false), Times.Once);
             _serviceMock.VerifyAll();
         }
     }

--- a/tests/FIAP.TechChallenge.ByteMeBurger.Application.Test/Services/OrderServiceTest.cs
+++ b/tests/FIAP.TechChallenge.ByteMeBurger.Application.Test/Services/OrderServiceTest.cs
@@ -42,11 +42,11 @@ public class OrderServiceTest
     {
         // Arrange
         var expectedOrders = new Fixture().CreateMany<Order>().ToList();
-        _mockOrderGetAllUseCase.Setup(r => r.Execute())
+        _mockOrderGetAllUseCase.Setup(r => r.Execute(true))
             .ReturnsAsync(expectedOrders.AsReadOnly);
 
         // Act
-        var result = await _target.GetAllAsync();
+        var result = await _target.GetAllAsync(true);
 
         // Assert
         using (new AssertionScope())
@@ -54,7 +54,7 @@ public class OrderServiceTest
             result.Should().NotBeNull();
             result.Should().NotBeEmpty();
             result.Should().BeEquivalentTo(expectedOrders);
-            _mockOrderGetAllUseCase.Verify(m => m.Execute(), Times.Once);
+            _mockOrderGetAllUseCase.Verify(m => m.Execute(true), Times.Once);
         }
     }
 
@@ -62,18 +62,18 @@ public class OrderServiceTest
     public async Task GetAll_Empty()
     {
         // Arrange
-        _mockOrderGetAllUseCase.Setup(r => r.Execute())
+        _mockOrderGetAllUseCase.Setup(r => r.Execute(true))
             .ReturnsAsync(Array.Empty<Order>().AsReadOnly);
 
         // Act
-        var result = await _target.GetAllAsync();
+        var result = await _target.GetAllAsync(true);
 
         // Assert
         using (new AssertionScope())
         {
             result.Should().NotBeNull();
             result.Should().BeEmpty();
-            _mockOrderGetAllUseCase.Verify(m => m.Execute(), Times.Once);
+            _mockOrderGetAllUseCase.Verify(m => m.Execute(true), Times.Once);
         }
     }
 


### PR DESCRIPTION
- it now allows the client to choose whether it wants to list all the orders or just the ones with specific statuses